### PR TITLE
Fix：程序窗口关闭时未正确清理 hosts 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ dist/
 *.spec
 log.txt
 *.pyc
+/.vs

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ pyperclip
 Requests
 requests_toolbelt
 pyinstaller
+pywin32

--- a/src/main.py
+++ b/src/main.py
@@ -26,7 +26,8 @@ import os
 import sys
 import ctypes
 import atexit
-import signal
+import win32api
+import win32con
 import requests
 import requests.packages
 
@@ -43,11 +44,16 @@ m_proxy = None
 
 
 def handle_exit():
+    logger.info("程序关闭，正在清理 hosts ！")
+    m_hostmgr.remove(genv.get("DOMAIN_TARGET"))  # 无论如何退出都应该进行清理
     print("再见!")
-    if m_hostmgr != None:
-        # pass
-        m_hostmgr.remove(genv.get("DOMAIN_TARGET"))
-    os.system("pause")
+
+
+def ctrl_handler(ctrl_type):
+    if ctrl_type == 2:  # 对应CTRL_CLOSE_EVENT
+        handle_exit()
+        return False
+    return True
 
 
 def initialize():
@@ -70,8 +76,6 @@ def initialize():
 
     # handle exit
     atexit.register(handle_exit)
-    signal.signal(signal.SIGTERM, handle_exit)
-    signal.signal(signal.SIGINT, handle_exit)
 
     # initialize object
     global m_certmgr, m_hostmgr, m_proxy
@@ -136,6 +140,12 @@ def welcome():
 
 
 if __name__ == "__main__":
+    # 设置控制台事件处理器
+    kernel32 = ctypes.WinDLL("kernel32")
+    HandlerRoutine = ctypes.WINFUNCTYPE(ctypes.c_bool, ctypes.c_uint)
+    handle_ctrl = HandlerRoutine(ctrl_handler)
+    kernel32.SetConsoleCtrlHandler(handle_ctrl, True)
+
     genv.set("FP_WORKDIR", os.path.join(os.environ["PROGRAMDATA"], "idv-login"))
     if not os.path.exists(genv.get("FP_WORKDIR")):
         os.mkdir(genv.get("FP_WORKDIR"))


### PR DESCRIPTION
使用 win32api 替换工作不正常的 signal，signal 并不能在窗口关闭时正确执行 handle_exit()

所以新增了 pywin32 依赖

现在它已经在：编译成 .exe 文件、命令行运行程序，两种情况下，直接关闭窗口也会正常清理 hosts